### PR TITLE
Added the ability to paginate through results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,56 @@ Insert an empty `div` in the code
 
 Run the plugin
 
-    $(document).ready(function() {
+    $(function() {
       $(".instagram").instagram({
-        hash: 'hfarm',
-        clientId: 'your-client-id-here'
+          hash: 'hfarm'
+        , clientId: 'your-client-id-here'
       });
     });
+
+An alternative method. This expects a div with class `instagram` and a `button`. When clicked, the button paginates through the search, allowing you to show more than the API limit of 20 photos.
+
+
+HTML
+	
+	<div class="instagram"></div>
+	<button>More</button>
+
+JS
+
+	$(function(){
+		var
+			  insta_container = $(".instagram")
+			, insta_next_url
+
+		 insta_container.instagram({
+			  hash: 'hipster'
+			, clientId : 'xxxxxxx'
+			, show : 18
+			, onComplete : function (photos, data) {
+				insta_next_url = data.pagination.next_url
+			}
+		 })
+
+		$('button').on('click', function(){
+			var 
+				  button = $(this)
+				, text = button.text()
+			
+			if (button.text() != 'Loading…'){
+				button.text('Loading…')
+				insta_container.instagram({
+					  next_url : insta_next_url
+					, show : 18
+					, onComplete : function(photos, data) {
+						insta_next_url = data.pagination.next_url
+						button.text(text)
+					}
+				})
+			}		
+		}) 
+	});
+
 
 ## Options
 
@@ -55,6 +99,13 @@ Type: `Number`
 
 Default: `null`
 
+### next_url
+You can populate this with the next url object (`pagination.next_url`) returned by the Instagram API.
+
+Type: `url`
+
+Default: `null`
+
 ### onLoad
 
 Called just before making the request to instagram API.
@@ -74,3 +125,5 @@ Default: `null`
 ## Acknowledgements
 
 Thanks to [@dpvitt](http://twitter.com/dpvitt) for the initial implementation.
+
+Thanks to [@photomak](https://github.com/potomak/jquery-instagram) for the v0.2

--- a/jquery.instagram.js
+++ b/jquery.instagram.js
@@ -3,15 +3,16 @@
     var that = this,
         apiEndpoint = "https://api.instagram.com/v1",
         settings = {
-          hash: null,
-          search: null,
-          accessToken: null,
-          clientId: null,
-          show: null,
-          onLoad: null,
-          onComplete: null,
-          maxId: null,
-          minId: null
+            hash: null
+          , search: null
+          , accessToken: null
+          , clientId: null
+          , show: null
+          , onLoad: null
+          , onComplete: null
+          , maxId: null
+          , minId: null
+          , next_url: null
         };
         
     options && $.extend(settings, options);
@@ -33,9 +34,13 @@
     }
     
     function composeRequestURL() {
+
       var url = apiEndpoint,
           params = {};
       
+      if (settings.next_url != null)
+      	return settings.next_url
+
       if(settings.hash != null) {
         url += "/tags/" + settings.hash + "/media/recent";
       }
@@ -53,8 +58,10 @@
       
       settings.accessToken != null && (params.access_token = settings.accessToken);
       settings.clientId != null && (params.client_id = settings.clientId);
+      settings.minId != null && (params.min_id = settings.minId);
+      settings.maxId != null && (params.max_id = settings.maxId);
 
-      url += "?" + $.param(params);
+      url += "?" + $.param(params)
       
       return url;
     }
@@ -67,13 +74,14 @@
       cache: false,
       url: composeRequestURL(),
       success: function(res) {
-        settings.onComplete != null && typeof settings.onComplete == 'function' && settings.onComplete(res.data);
         
         var limit = settings.show == null ? res.data.length : settings.show;
         
         for(var i = 0; i < limit; i++) {
           that.append(createPhotoElement(res.data[i]));
         }
+
+        settings.onComplete != null && typeof settings.onComplete == 'function' && settings.onComplete(res.data, res);
       }
     });
     


### PR DESCRIPTION
Instagram returns a an object called `pagination` that we can use to get more photos. This adds a settings called `next_url` which you can optionally populate to paginate through the results.

Note: for backward compatibility, the `onComplete` function now returns two parameters:

```
onComplete : function (res.data, res)
```
- `res.data` is an object that contains just the photos
- `res` is the full result, which contains the `pagination` object as well as the photos object. Really, we could do with just this param, but we don't want to kill older programs which expect the first param to be just the photos
