### PR TITLE
requesting only as many pictures from instagram api as we'll show

### DIFF
--- a/jquery.instagram.js
+++ b/jquery.instagram.js
@@ -76,6 +76,7 @@
       settings.clientId != null && (params.client_id = settings.clientId);
       settings.minId != null && (params.min_id = settings.minId);
       settings.maxId != null && (params.max_id = settings.maxId);
+      settings.show != null && (params.count = settings.show);
 
       url += "?" + $.param(params)
       


### PR DESCRIPTION
Currently when we do the api request to instagram we're not defining the count of pictures to return. So if we want to show 4 pictures, we'll get possibly 10 pictures back from instagram, but only actually show 1-4. But when we paginate we'll now get pictures 11-20, but only end up showing pictures 11-14. So all in all we'd show 1-4, and 11-14, skipping a lot of pictures.

I noticed this issue when I was trying to show pictures from my personal feed and was not showing certain pictures.

This fix adds a parameter to the api call to instagram to only request the number of photos we intend to show. That way the pagination will show us the next set.

The documentation for this parameter to the api call is found at http://instagram.com/developer/endpoints/users/
