### PR TITLE
Default to empty string if data values not defined.

### DIFF
--- a/src/instagram.js
+++ b/src/instagram.js
@@ -17,9 +17,9 @@
     }
 
     data = $.extend(data, {
-      access_token: options.accessToken,
-      client_id: options.clientId,
-      count: options.count
+      access_token: options.accessToken || '',
+      client_id: options.clientId || '',
+      count: options.count || ''
     });
 
     if (options.url != null) {


### PR DESCRIPTION
I was adding this plugin to a site with jQuery 1.7 and authentication with Instagram was failing as the string "null" was being passed as the OAuth token (due to [this jQuery bug](http://bugs.jquery.com/ticket/8653)).

Can understand if you're not worried about supporting older versions of jQuery, but this minor change makes the plugin work out of the box with jQuery 1.7 without affecting any other functionality.
